### PR TITLE
Fixes issues with EntitySelected-Event and ticketcreation

### DIFF
--- a/Samba.Modules.PosModule/PosViewModel.cs
+++ b/Samba.Modules.PosModule/PosViewModel.cs
@@ -168,7 +168,6 @@ namespace Samba.Modules.PosModule
         {
             if (eventParameters.Topic == EventTopicNames.EntitySelected)
             {
-                FireEntitySelectedRule(eventParameters.Value.SelectedItem);
                 if (SelectedTicket != null)
                 {
                     _ticketService.UpdateEntity(SelectedTicket, eventParameters.Value.SelectedItem);
@@ -216,6 +215,7 @@ namespace Samba.Modules.PosModule
                     }
                     EventServiceFactory.EventService.PublishEvent(EventTopicNames.ActivatePosView);
                 }
+                FireEntitySelectedRule(eventParameters.Value.SelectedItem);
             }
         }
 
@@ -234,6 +234,7 @@ namespace Samba.Modules.PosModule
                             EntityCustomData = entity.CustomData,
                             IsTicketSelected = SelectedTicket != null
                         });
+                    EventServiceFactory.EventService.PublishEvent(EventTopicNames.ActivatePosView); //Refreshes the view of the ticket => refactor this to a "RefreshTicketView"-Action
                 }
             }
         }


### PR DESCRIPTION
When I investigated the posibility for linking entities together (see #243 for reference) I discovered that the EntitySelected-Event is fired befor a ticket is created and if you let this rule create a ticket with the CanCreateTicket-Option this ticket isn't used any further.

I think the time when the EntitySelected-Event fires is wrong. Not only conceptionaly (it is more important that the entity is fully selected and a needet ticket is already created or selected befor anything else has to be done with it) but also wording wise (Selected = past-tense => occurs after the Entety is selected).

This commit fires the EntetySelected-Rule after a ticket is created or selected.
I also added a refresh of the Ticket-View. This could be refactored to a "RefreshTicketView"-Action.

I will also write a how-to on how to link entites together in the forum.
