### PR TITLE
Added ability to use a custom Database and Schema

### DIFF
--- a/Samba.Infrastructure/Settings/LocalSettings.cs
+++ b/Samba.Infrastructure/Settings/LocalSettings.cs
@@ -17,6 +17,7 @@ namespace Samba.Infrastructure.Settings
         public string MessagingServerName { get; set; }
         public string TerminalName { get; set; }
         public string ConnectionString { get; set; }
+        public string DatabaseSchema { get; set; }
         public bool StartMessagingClient { get; set; }
         public string LogoPath { get; set; }
         public string DefaultHtmlReportHeader { get; set; }
@@ -104,6 +105,12 @@ html
         {
             get { return _settingsObject.ConnectionString; }
             set { _settingsObject.ConnectionString = value; }
+        }
+
+        public static string DatabaseSchema
+        {
+            get { return _settingsObject.DatabaseSchema; }
+            set { _settingsObject.DatabaseSchema = value; }
         }
 
         public static bool StartMessagingClient


### PR DESCRIPTION
I recently used SambaPOS3 to simulate a POS transaction on a demo and had make some changes to make the application run using a database with a name different than the AppName and also to use a database schema different than dbo. I decided to share my changes in case somebody else is interested.

The database name is now been read from the connection string.

The custom schema name is optional and can be set directly on the local settings file.

Because of the version of EF been currently used, changing the schema requires specifying the new value for every single entity in the application. Please let me know if I missed any.
